### PR TITLE
Remove duplicate workflow run

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,10 @@
 name: "Build"
-on: [ push, pull_request ]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, reopened, synchronize]
 jobs:
   build:
     strategy:


### PR DESCRIPTION
Previously there was overlapping triggers for the main workflow which
causes the same job to run multiple times when utilizing pull requests.

This commit ensures that the main workflow is run on each push to the
main branch, and when any pull request is opened, reopened, or
the source branch is changed (synchronize).

This will reduce the time it takes for the workflow to run, reduce
runner queue time for other workflows and reduce GH Action
expenditures.