### PR TITLE
Bump JDK running Gradle from 11 to 17

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,30 +10,45 @@ jobs:
     strategy:
       matrix:
         include:
-          - { os: 'macos-latest', arch: 'x64', java-version: '11', gradle-version: '7.3' }
-          - { os: 'ubuntu-latest', arch: 'x64', java-version: '11', gradle-version: '7.3' }
-          - { os: 'windows-latest', arch: 'x64', java-version: '11', gradle-version: '7.3' }
-    name: Gradle ${{ matrix.gradle-version }}, Java ${{ matrix.java-version }} on ${{ matrix.os }} (${{ matrix.arch }})
+          - { os: 'macos-latest', arch: 'x64', toolchain-jdk: '11', gradle-jdk: '17', gradle-version: '7.3' }
+          - { os: 'ubuntu-latest', arch: 'x64', toolchain-jdk: '11', gradle-jdk: '17', gradle-version: '7.3' }
+          - { os: 'windows-latest', arch: 'x64', toolchain-jdk: '11', gradle-jdk: '17', gradle-version: '7.3' }
+    name: >
+      Gradle ${{ matrix.gradle-version }} w/JDK ${{ matrix.gradle-jdk }}
+      on ${{ matrix.os }} (${{ matrix.arch }}) and toolchain JDK ${{ matrix.toolchain-jdk}}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - name: Configure JDK ${{ matrix.java-version }} (${{ matrix.arch }})
+      - name: Configure JDK ${{ matrix.gradle-jdk }} (${{ matrix.arch }})
+        id: configure-gradle-jdk
         uses: actions/setup-java@v2
         with:
           architecture: ${{ matrix.arch }}
           distribution: 'temurin'
-          java-version: ${{ matrix.java-version }}
-      - uses: gradle/gradle-build-action@v2
+          java-version: ${{ matrix.gradle-jdk }}
+      - name: Configure JDK ${{ matrix.toolchain-jdk }} (${{ matrix.arch }})
+        id: configure-toolchain-jdk
+        uses: actions/setup-java@v2
+        with:
+          architecture: ${{ matrix.arch }}
+          distribution: 'temurin'
+          java-version: ${{ matrix.toolchain-jdk }}
+      - name: Build project
+        uses: gradle/gradle-build-action@v2
         with:
           # Only write to the cache on the 'main' branch
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
           gradle-version: ${{ matrix.gradle-version }}
-          arguments: build --scan
+          arguments: >
+            build --scan
+            -Dorg.gradle.java.installations.auto-detect=false
+            -Dorg.gradle.java.installations.auto-download=false
+            -Dorg.gradle.java.installations.paths=${{ steps.configure-gradle-jdk.outputs.path }},${{ steps.configure-toolchain-jdk.outputs.path }}
       - name: Upload build reports
         uses: actions/upload-artifact@v2
         if: always()
         with:
-          name: build-reports-${{ matrix.os }}-${{ matrix.arch }}-jdk-${{ matrix.java-version }}
+          name: build-reports-${{ matrix.os }}-${{ matrix.arch }}-gradle-jdk-${{ matrix.gradle-jdk }}-toolchain-jdk-${{ matrix.toolchain-jdk }}
           path: |
             build/reports
             ./**/build/reports

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -11,6 +11,7 @@ plugins {
   id("org.jlleitschuh.gradle.ktlint") version "10.2.0"
 }
 
+val jdkVersion: JavaLanguageVersion = JavaLanguageVersion.of(11)
 val functionalTestSourceSet: SourceSet = sourceSets.create("functionalTest")
 configurations["functionalTestImplementation"].extendsFrom(configurations["testImplementation"])
 
@@ -27,6 +28,18 @@ gradlePlugin {
     displayName = "Deno Gradle Plugin"
     description = "Use Deno, a runtime for JavaScript and Typescript, as part of your Gradle build."
     implementationClass = "org.rognan.gradle.deno.DenoPlugin"
+  }
+}
+
+java {
+  toolchain {
+    languageVersion.set(jdkVersion)
+  }
+}
+
+kotlin {
+  jvmToolchain {
+    (this as JavaToolchainSpec).languageVersion.set(jdkVersion)
   }
 }
 


### PR DESCRIPTION
    This commit decouples the JDK running Gradle from the one building the
    project.
    
    Gradle will by default use the same JDK for building the project as it
    does for running Gradle. Newer JDKs are assumed to be more performant,
    contain fewer bugs and to come with desirable features that we would
    like to utilize in our build, but doing so should not endanger
    backwards compatibility for the plugin itself. We can do that now by
    utilizing Gradle toolchains, which allows us to use one JDK/JRE for
    running Gradle and the other for building the project, i.e. executing
    `javac`.
    
    Doing this requires us to make multiple JDKs available to the Gradle
    build action for each individual execution of the build. The setup-java
    action doesn't support this at the moment, and the multiple build steps
    configured for actions/setup-java in this commit is at best a
    workaround for this, and at worst a bad assumption with respect to
    environment variables or other settings being overwritten. Furthermore,
    there's no handling of duplicate invocations of the action.
    
    Hopefully both actions/setup-java and gradle/gradle-build-action will
    handle all of this gracefully.
