### PR TITLE
Add dependency-review job-summary as comment on PR

### DIFF
--- a/.github/workflows/review-pr.yml
+++ b/.github/workflows/review-pr.yml
@@ -9,11 +9,15 @@ jobs:
       - uses: actions/checkout@v4.1.2
       - uses: gradle/wrapper-validation-action@v2.1.2
   review-dependencies:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.2
       - uses: actions/dependency-review-action@v4.2.3
         with:
+          comment-summary-in-pr: always
           retry-on-snapshot-warnings: true
           retry-on-snapshot-warnings-timeout: 600
           allow-dependencies-licenses: "pkg:maven/org.openjdk.nashorn/nashorn-core@15.4?type=jar"


### PR DESCRIPTION
In some situations the dependency-review-action will issue a warning
in the job-summary instead of failing the build.

Examples include when the dependency graph is still unavailable to the
action when `retry-on-snapshot-warnings-timeout` is reached, or when a
dependency's license cannot be determined.

When a warning is issued a manual review should be performed and this
change makes the warnings easier to notice for the one merging the PR.
