### PR TITLE
Remove unnecessary runtimeOnly dependency

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -76,5 +76,4 @@ dependencies {
   implementation("gradle.plugin.org.jetbrains.gradle.plugin.idea-ext:gradle-idea-ext:1.1.7")
   implementation("com.diffplug.spotless-changelog:spotless-changelog-plugin-gradle:3.0.2")
   implementation("com.diffplug.spotless:spotless-plugin-gradle:6.25.0")
-  runtimeOnly("org.openjdk.nashorn:nashorn-core:15.4")
 }


### PR DESCRIPTION
Nashorn JavaScript Engine, required by FreshMark, was removed from the
JDK with the release of JDK 15 and JEP 372.

The `spotless-plugin-gradle` plugin ensured nashorn-core was on the
classpath for all JVMs >= 15 in version 6.14.1.
