### PR TITLE
Validate Gradle wrapper when running main workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Configure Gradle
         uses: gradle/actions/setup-gradle@v3.3.1
         with:
+          validate-wrappers: true
           cache-encryption-key: ${{ secrets.GradleEncryptionKey }}
       - name: Execute build
         run: >


### PR DESCRIPTION
While the review-pr workflow will fail when a wrapper with an erroneous
hash is detected, this does not prevent the main workflow from running
with a potentially corrupted wrapper.
